### PR TITLE
Minor fix in HTMLFetcher for HTTPS urls

### DIFF
--- a/src/main/java/com/jimplush/goose/network/HtmlFetcher.java
+++ b/src/main/java/com/jimplush/goose/network/HtmlFetcher.java
@@ -31,6 +31,7 @@ import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.conn.params.ConnPerRoute;
 import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.conn.scheme.PlainSocketFactory;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
 import org.apache.http.cookie.Cookie;
@@ -277,7 +278,7 @@ public class HtmlFetcher {
 
     SchemeRegistry schemeRegistry = new SchemeRegistry();
     schemeRegistry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-    schemeRegistry.register(new Scheme("https", PlainSocketFactory.getSocketFactory(), 443));
+    schemeRegistry.register(new Scheme("https", SSLSocketFactory.getSocketFactory(), 443));
 
     final ClientConnectionManager cm = new ThreadSafeClientConnManager(httpParams, schemeRegistry);
 


### PR DESCRIPTION
Using SSLSocketFactory instead of PlainSocketFactory for HTTPS.

Are there any plans to upgrade to Apache HttpComponents 4.1.x ? If you wish, I can go ahead with this work.
