### PR TITLE
Use line.separator to split Stopwords

### DIFF
--- a/src/main/scala/com/gravity/goose/text/StopWords.scala
+++ b/src/main/scala/com/gravity/goose/text/StopWords.scala
@@ -32,7 +32,7 @@ object StopWords {
   // the confusing pattern below is basically just match any non-word character excluding white-space.
   private val PUNCTUATION: StringReplacement = StringReplacement.compile("[^\\p{Ll}\\p{Lu}\\p{Lt}\\p{Lo}\\p{Nd}\\p{Pc}\\s]", string.empty)
 
-  val STOP_WORDS = FileHelper.loadResourceFile("stopwords-en.txt", StopWords.getClass).split("\n").toSet
+  val STOP_WORDS = FileHelper.loadResourceFile("stopwords-en.txt", StopWords.getClass).split(sys.props("line.separator")).toSet
 
 
   def removePunctuation(str: String): String = {


### PR DESCRIPTION
Windows converts new lines to _"\r\n"_ whereas the stop word file is split using _"\n"_. So all stop words have a carriage return at the end. All tests fail since no stop words are matched.

Replaced

``` scala
split("\n")
```

with

``` scala
split(sys.props("line.separator"))
```
