### PR TITLE
Add image width and height to UpgradedImageIExtractor.scala

### DIFF
--- a/src/main/scala/com/gravity/goose/images/UpgradedImageIExtractor.scala
+++ b/src/main/scala/com/gravity/goose/images/UpgradedImageIExtractor.scala
@@ -113,6 +113,8 @@ class UpgradedImageIExtractor(httpClient: HttpClient, article: Article, config: 
             mainImage.imageSrc = highScoreImage._1.imgSrc
             mainImage.imageExtractionType = "bigimage"
             mainImage.bytes = highScoreImage._1.bytes
+            mainImage.width = highScoreImage._1.width
+            mainImage.height = highScoreImage._1.height
             mainImage.confidenceScore = if (scoredImages.size > 0) (100 / scoredImages.size) else 0
             trace("IMAGE COMPLETE: High Score Image is: " + mainImage.imageSrc + " Score is: " + highScoreImage._2)
             return Some(mainImage)


### PR DESCRIPTION
Hey, looks like this was missing! 

Was wondering as well if you'd consider merging my previous two requests, #67 and #68, they are just minor changes but currently I maintaining my own fork and publishing to Sonatype's maven repo, would be fantastic to be able to push back upstream.   
