### PR TITLE
Do not use absolute path for ImageMagick tools

### DIFF
--- a/src/main/scala/com/gravity/goose/Configuration.scala
+++ b/src/main/scala/com/gravity/goose/Configuration.scala
@@ -55,12 +55,12 @@ class Configuration {
   * path to your imagemagick convert executable, on the mac using mac ports this is the default listed
   */
   @BeanProperty
-  var imagemagickConvertPath: String = "/opt/local/bin/convert"
+  var imagemagickConvertPath: String = "convert"
   /**
   *  path to your imagemagick identify executable
   */
   @BeanProperty
-  var imagemagickIdentifyPath: String = "/opt/local/bin/identify"
+  var imagemagickIdentifyPath: String = "identify"
 
   @BeanProperty
   var connectionTimeout: Int = 10000


### PR DESCRIPTION
I guess the default configuration should not use absolute path to convert and identify.

People can overwrite that by using setImagemagickConvertPath/setImagemagickIdentifyPath methods.
