### PR TITLE
Escalate exception in Image extraction

### DIFF
--- a/src/main/scala/com/gravity/goose/Crawler.scala
+++ b/src/main/scala/com/gravity/goose/Crawler.scala
@@ -88,7 +88,8 @@ class Crawler(config: Configuration) {
               }
             } catch {
               case e: Exception => {
-                warn(e, e.toString)
+                warn(e, e.getMessage)
+                throw e
               }
             }
           }


### PR DESCRIPTION
In the method crawl, when there is an exception during the extraction of the main image, it is probably better to throw the original exception outside. Basing on this approach it is possible to wrap the exception in a Try block and then handle it outside the library.
