### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-#Goose - Article Extractor
+# Goose - Article Extractor
 
-##Intro
+## Intro
 
 
 Goose was originally an article extractor written in Java that has most recently (aug2011) converted to a scala project. It's mission is to take any news article or article type web page and not only extract what is the main body of the article but also all meta data and most probable image candidate.
@@ -30,12 +30,12 @@ Try it out online!
 http://jimplush.com/blog/goose
 
 
-##Licensing
+## Licensing
 If you find Goose useful or have issues please drop me a line, I'd love to hear how you're using it or what features should be improved
 
 Goose is licensed by Gravity.com under the Apache 2.0 license, see the LICENSE file for more details
 
-##Take it for a spin
+## Take it for a spin
 To use goose from the command line:
 
     cd into the goose directory
@@ -43,7 +43,7 @@ To use goose from the command line:
     MAVEN_OPTS="-Xms256m -Xmx2000m"; mvn exec:java -Dexec.mainClass=com.gravity.goose.TalkToMeGoose -Dexec.args="http://techcrunch.com/2011/05/13/native-apps-or-web-apps-particle-code-wants-you-to-do-both/" -e -q > ~/Desktop/gooseresult.txt
 
 
-##Regarding the port from JAVA to Scala
+## Regarding the port from JAVA to Scala
 
 Here are some of the reasons for the port to Scala:
 
@@ -53,6 +53,6 @@ Here are some of the reasons for the port to Scala:
  - Scala is more fun
 
 
-##Issues
+## Issues
 It was a pretty fast Java to Scala port so lots of the nicities of the Scala language aren't in the codebase yet, but those will come over the coming months as we re-write alot of the internal methods to be more Scalesque.
 We made sure it was still nice and operable from Java as well so if you're using goose from java you still should be able to use it with a few changes to the method signatures.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
